### PR TITLE
Enable and Disable button for each merchant item

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,17 @@
+class ItemsController < ApplicationController
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
+  def update_status
+    @item = Item.find(params[:id])
+    if params[:status] == 'enable'
+      @item.update(status: 1)
+    elsif params[:status] == 'disable'
+      @item.update(status: 0)
+    end
+    redirect_to "/items/#{@item.id}"
+  end
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,4 +3,6 @@ class Item < ApplicationRecord
   has_many :invoices, through: :invoice_items
   belongs_to :merchant
 
+  enum status: [:Disabled, :Enabled]
+
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,3 @@
+<h1> Item: <%= @item.name %> </h1>
+
+<p>Status: <%= @item.status %>  </p>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,5 +1,10 @@
 <h1>Merchant Items:</h1>
-<p>----------------------</p>
+<hr>
 <% @merchant.items.each do |item| %>
 <p><b>Name:</b> <%= item.name %> </p>
+<% if item.status == "Disabled" %>
+<%= button_to "Enable #{item.name}", "/items/#{item.id}?status=enable", method: :patch %>
+<% elsif item.status == "Enabled" %>
+<%= button_to "Disable #{item.name}", "/items/#{item.id}?status=disable", method: :patch %>
+<% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,7 @@ Rails.application.routes.draw do
   get '/merchant/:id/dashboard', to: 'merchants#show'
   get '/merchants/:id/items', to: 'merchant_items#index'
   get '/merchant/:id/invoices', to: 'merchant_invoices#index'
+
+  get '/items/:id', to: 'items#show'
+  patch 'items/:id', to: 'items#update_status'
 end

--- a/db/migrate/20220219212948_add_status_to_items.rb
+++ b/db/migrate/20220219212948_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_17_220749) do
+ActiveRecord::Schema.define(version: 2022_02_19_212948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2022_02_17_220749) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -20,4 +20,24 @@ RSpec.describe 'the merchant item index page' do
     expect(page).to_not have_content(@item_3.name)
     expect(page).to_not have_content(@item_4.name)
   end
+
+  it "Can enable and disable an item" do
+    visit "/items/#{@item_1.id}"
+
+    expect(page).to have_content("Status: Disabled")
+
+    visit "/merchants/#{@merchant_1.id}/items"
+
+    expect(page).to have_button("Enable #{@item_1.name}")
+
+    click_button("Enable #{@item_1.name}")
+
+    expect(current_path).to eq("/items/#{@item_1.id}")
+
+    expect(page).to have_content("Status:")
+
+    @item_1.reload
+    
+    expect(@item_1.status).to eq("Enabled")
+  end
 end


### PR DESCRIPTION
There will be merge conflicts
Inside Merchant Items Index page - 
- All items are currently disabled
- Added a button next to each Merchant Item 
- If Item is disabled, an enable button will show
- vise versa - if Item is enabled, the disable button will show
- Updated the Items Status! 