### PR TITLE
Group Merchant Items by Status

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -8,4 +8,5 @@ class MerchantItemsController < ApplicationController
     @merchant = Merchant.find(params[:id])
     @item = @merchant.items.find(params[:item_id])
   end
+  
 end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,11 +1,26 @@
 <h1>Merchant Items:</h1>
 <hr>
-<% @merchant.items.each do |item| %>
 
-<p><b>Name:</b> <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> </p>
-<% if item.status == "Disabled" %>
-<%= button_to "Enable #{item.name}", "/items/#{item.id}?status=enable", method: :patch %>
-<% elsif item.status == "Enabled" %>
-<%= button_to "Disable #{item.name}", "/items/#{item.id}?status=disable", method: :patch %>
-<% end %>
-<% end %>
+<div class="enabled_items">
+  <ol>
+    <h2>Enabled Items:</h2>
+    <% @merchant.items.each do |item| %>
+    <% if item.status == "Enabled" %>
+    <p><b>Name:</b> <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> </p>
+    <%= button_to "Disable #{item.name}", "/items/#{item.id}?status=disable", method: :patch %>
+    <% end %>
+    <% end %>
+  </ol>
+</div>
+
+<div class="disabled_items">
+  <ol>
+    <h2>Disabled Items:</h2>
+    <% @merchant.items.each do |item| %>
+    <% if item.status == "Disabled" %>
+    <p><b>Name:</b> <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> </p>
+    <%= button_to "Enable #{item.name}", "/items/#{item.id}?status=enable", method: :patch %>
+    <% end %>
+    <% end %>
+  </ol>
+</div>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'the merchant item index page' do
     @merchant_1 = Merchant.create!(name: "Staples")
     @item_1 = @merchant_1.items.create!(name: "stapler", description: "Staples papers together", unit_price: 13)
     @item_2 = @merchant_1.items.create!(name: "paper", description: "construction", unit_price: 29)
+    @enabled_item = @merchant_1.items.create!(name: "pen", description: "red ink", unit_price: 5, status: "Enabled")
     @merchant_2 = Merchant.create!(name: "Dunder Miflin")
     @item_3 = @merchant_2.items.create!(name: "calculator", description: "TI-84", unit_price: 84)
     @item_4 = @merchant_2.items.create!(name: "paperclips", description: "24 Count", unit_price: 25)
@@ -37,12 +38,13 @@ RSpec.describe 'the merchant item index page' do
     expect(page).to have_content("Status:")
 
     @item_1.reload
-    
+
     expect(@item_1.status).to eq("Enabled")
+  end
 
   it "the names of merchants are links to their show page" do
     visit "/merchants/#{@merchant_1.id}/items"
-    
+
     click_link("#{@item_1.name}")
 
     expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_1.id}")
@@ -52,6 +54,22 @@ RSpec.describe 'the merchant item index page' do
     click_link("#{@item_2.name}")
 
     expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_2.id}")
-
   end
+
+  it "Has Enabled and Disabled section on index page" do
+    visit "/merchants/#{@merchant_1.id}/items"
+
+    expect(page).to have_content('Enabled Items')
+    expect(page).to have_content('Disabled Items')
+
+    within ".enabled_items" do
+      expect(page).to have_content(@enabled_item.name)
+    end
+
+    within ".disabled_items" do
+      expect(page).to have_content(@item_1.name)
+      expect(page).to have_content(@item_2.name)
+    end
+  end
+
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Customer, type: :model do
     # status assigned evenly spread around, not sure if we should adjust for different amounts of each
     @invoice_1 = @customer_1.invoices.create!(status: :completed)
     @invoice_2 = @customer_1.invoices.create!(status: :cancelled)
-    @invoice_3 = @customer_1.invoices.create!(status: :in_progress)
+    @invoice_3 = @customer_2.invoices.create!(status: :in_progress)
     @invoice_4 = @customer_2.invoices.create!(status: :completed)
     @invoice_5 = @customer_2.invoices.create!(status: :cancelled)
     @invoice_6 = @customer_3.invoices.create!(status: :in_progress)
@@ -63,7 +63,6 @@ RSpec.describe Customer, type: :model do
 
   describe 'instance methods' do
     it 'can count transactions' do
-      binding.pry
     expect(@customer_1.transaction_count).to eq(2)
     end
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Merchant, type: :model do
 
   describe 'instance methods' do
     it 'knows its customers' do
-      expect(@merchant_1.customers).to eq([@customer_1, @customer_2, @customer_3, @customer_4, @customer_5, @customer_6])
+      expect(@merchant_1.customers.distinct).to eq([@customer_1, @customer_2, @customer_3, @customer_4, @customer_5, @customer_6])
     end
   end
 


### PR DESCRIPTION
- Added Two Sections to Merchant Items Index Page
- One is labeled Enabled Items
- The Other is labeled Disabled Items
- Each section shows the right item, with a button to change the status