### PR TITLE
Refactor: Combine order by method to ship ready items

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -1,6 +1,5 @@
 class MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
-    @shippable_invoice_items = @merchant.ship_ready_items.order_by_oldest
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -2,8 +2,4 @@ class InvoiceItem < ApplicationRecord
   belongs_to :invoice
   belongs_to :item
   enum status: {"pending" => 0, "packaged" => 1, "shipped" => 2}
-
-  def self.order_by_oldest
-    order(:created_at)
-  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,6 +8,7 @@ class Merchant < ApplicationRecord
   def ship_ready_items
     invoice_items.joins(:invoice) #ask at check in
                   .where.not(status: 2)
+                  .order(:created_at)
   end
 
   def customers_list

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -14,7 +14,7 @@
 
 <h2> Items ready to ship </h2>
 <div class="items-ready-to-ship">
-  <% @shippable_invoice_items.each do |invoice_item| %>
+  <% @merchant.ship_ready_items.each do |invoice_item| %>
     <li>
       <%= "#{invoice_item.item.name}" %>
       <%= link_to "Order number: #{invoice_item.invoice.id}", "/merchant/#{@merchant.id}/invoices/#{invoice_item.invoice.id}" %>

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Merchant, type: :model do
       expect(@merchant_1.customers_list).to eq([@customer_1, @customer_2, @customer_3, @customer_4, @customer_5, @customer_6])
     end
 
-    xit '.ship_ready_items' do
+    it '.ship_ready_items' do
       expect(@merchant_1.ship_ready_items).to eq([@invoice_item_2, @invoice_item_3, @invoice_item_5, @invoice_item_6, @invoice_item_8, @invoice_item_9, @invoice_item_11, @invoice_item_12])
     end
 


### PR DESCRIPTION
### Features:
- Refactor ship_ready_items and order_by_oldest into one method
- Refactoring this way fixes Orderly gem error where sometimes an instance loads out of order
- Remove unnecessary controller instance
### Concerns:
- Top customers is now failing with the same Orderly error

### How does this PR make you feel?
![smort](https://media.giphy.com/media/5feFH4ASqc7Gvto3Er/giphy.gif)